### PR TITLE
Added jsonresume-theme-kwan-linkedin

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -33,6 +33,7 @@
     "jsonresume-theme-keloran": "^1.0.2",
     "jsonresume-theme-kendall": "^0.1.19",
     "jsonresume-theme-kwan": "0.0.2",
+    "jsonresume-theme-kwan-linkedin": "0.0.2",
     "jsonresume-theme-latex": "^0.1.1",
     "jsonresume-theme-mantra": "^0.2.0",
     "jsonresume-theme-mocha-responsive": "^1.0.0",


### PR DESCRIPTION
jsonresume-theme-kwan-linkedin is a derivative of the Kwan theme with date calculations that are similar to how LinkedIn calculates durations. This is important so that employers don't get confused and unnecessarily suspicious when double checking a Resume/CV against someone's LinkedIn profile.