### PR TITLE
Update version of jsonresume-theme-onepageresume in package.json

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -49,7 +49,7 @@
     "jsonresume-theme-modern": "0.0.18",
     "jsonresume-theme-msresume": "^0.1.0",
     "jsonresume-theme-onepage": "0.0.3",
-    "jsonresume-theme-onepageresume": "0.0.2",
+    "jsonresume-theme-onepageresume": "^0.0.3",
     "jsonresume-theme-orbit": "^1.0.3",
     "jsonresume-theme-paper": "^0.5.0",
     "jsonresume-theme-paper-plus-plus": "^0.5.0",


### PR DESCRIPTION
i've updated version of jsonresume-theme-onepageresume from @nabilbendafi to "^0.0.3" to use the new version of this theme.