### PR TITLE
functions: add stackoverflowed theme

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -62,6 +62,7 @@
     "jsonresume-theme-spartan": "^0.3.0",
     "jsonresume-theme-srt": "^0.1.3",
     "jsonresume-theme-stackoverflow": "^1.4.0",
+    "jsonresume-theme-stackoverflowed": "^1.1.2",
     "jsonresume-theme-standard-resume": "^1.3.0",
     "jsonresume-theme-tachyons-clean": "0.0.9",
     "jsonresume-theme-tan-responsive": "0.0.4",


### PR DESCRIPTION
👋 Howdy, thanks for the effort you've all put into JSON Resume, it has been a relief to find a replacement for StackOverflow Developer Stories (which they recently decided sunset). I've been working on a theme to replicate the format, which I'd like to share (this has no relation to the other SO related theme & derivatives available). 

 - ref: https://github.com/mylesj/jsonresume-theme-stackoverflowed

For full disclosure this theme can make outbound network requests to:

A) validate the profile image URL (lightweight `HEAD` request)
B) fallback to a [Gravatar](https://en.gravatar.com/) image (also a `HEAD` request)
C) retrieve a summary of StackOverflow profile activity (**disabled** by default - requires StackExchange API key)

I'm not familiar with firebase - is there a manifest that would gate keep network activity? If **A** & **B** are considered intrusive I can disable all activity by default and raise another PR?